### PR TITLE
Fix strict and description declarations

### DIFF
--- a/lib/ruby_llm/schema.rb
+++ b/lib/ruby_llm/schema.rb
@@ -30,7 +30,9 @@ module RubyLLM
       end
 
       def strict(value = nil)
-        return @strict ||= true if value.nil?
+        if value.nil?
+          return @strict.nil? ? (@strict = true) : @strict
+        end
         @strict = value
       end
 

--- a/lib/ruby_llm/schema.rb
+++ b/lib/ruby_llm/schema.rb
@@ -180,7 +180,7 @@ module RubyLLM
       
       {
         name: @name,
-        description: @description,
+        description: @description || self.class.description,
         schema: {
           :type => "object",
           :properties => self.class.properties,

--- a/spec/ruby_llm/schema_class_inheritance_spec.rb
+++ b/spec/ruby_llm/schema_class_inheritance_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe RubyLLM::Schema, "class inheritance approach" do
         expect(schema_class.description).to eq("Class-level description")
       end
 
+      it "applies to the schema properly" do
+        schema_class.description("Class-level description")
+        instance = schema_class.new
+        expect(instance.to_json_schema[:description]).to eq("Class-level description")
+      end
+
       it "defaults to nil when not provided" do
         expect(schema_class.description).to be_nil
       end
@@ -112,7 +118,7 @@ RSpec.describe RubyLLM::Schema, "class inheritance approach" do
 
       expect(json_output).to include(
         name: "ConfiguredSchema",
-        description: nil, # Instance description takes precedence
+        description: "Test description",
         schema: hash_including(
           type: "object",
           properties: { title: { type: "string" } },
@@ -120,6 +126,22 @@ RSpec.describe RubyLLM::Schema, "class inheritance approach" do
           additionalProperties: false,
           strict: true
         )
+      )
+    end
+
+    it "produces correctly structured JSON schema with instance description" do
+      configured_class = Class.new(described_class) do
+        description "Test description"
+        additional_properties false
+        string :title
+      end
+
+      instance = configured_class.new("ConfiguredSchema", description: "Instance description")
+      json_output = instance.to_json_schema
+
+      expect(json_output).to include(
+        name: "ConfiguredSchema",
+        description: "Instance description",
       )
     end
   end

--- a/spec/ruby_llm/schema_class_inheritance_spec.rb
+++ b/spec/ruby_llm/schema_class_inheritance_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe RubyLLM::Schema, "class inheritance approach" do
         expect(instance.to_json_schema[:schema][:strict]).to eq(true)
       end
 
+      it "can be set to false (explicit)" do
+        schema_class.strict(false)
+        instance = schema_class.new
+        expect(instance.to_json_schema[:schema][:strict]).to eq(false)
+      end
+
       it "defaults to true when not provided" do
         instance = schema_class.new
         expect(instance.to_json_schema[:schema][:strict]).to eq(true)

--- a/spec/ruby_llm/schema_factory_spec.rb
+++ b/spec/ruby_llm/schema_factory_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe RubyLLM::Schema, "factory method (.create) approach" do
 
       expect(json_output).to include(
         name: "FactoryConfiguredSchema",
-        description: nil, # Instance description takes precedence
+        description: "Factory test description",
         schema: hash_including(
           type: "object",
           properties: { title: { type: "string" } },
@@ -143,6 +143,22 @@ RSpec.describe RubyLLM::Schema, "factory method (.create) approach" do
           additionalProperties: false,
           strict: true
         )
+      )
+    end
+
+    it "produces correctly structured JSON schema with instance description" do
+      configured_class = described_class.create do
+        description "Factory test description"
+        additional_properties false
+        string :title
+      end
+
+      instance = configured_class.new("FactoryConfiguredSchema", description: "Instance description")
+      json_output = instance.to_json_schema
+
+      expect(json_output).to include(
+        name: "FactoryConfiguredSchema",
+        description: "Instance description",
       )
     end
   end


### PR DESCRIPTION
Using `strict false` or `description "my description"` at the class level are not correctly applying to the schema.

This PR fixes both issues. Each issue is fixed in distinct commits and specs were added that were failing without the change.

Each bug stemmed from a distinct issue:
https://github.com/danielfriis/ruby_llm-schema/commit/5c67bbcd4fe65b0ae139bd1813865671c1d91238 - `@strict ||= true` would always return true even if `@strict` was `false`
https://github.com/danielfriis/ruby_llm-schema/commit/d3a46ad00a6e94ef8ffcc63bffd684419e7f79bd - it wasn't true that the instance description would take precedence over the class description; the class description was completely ignore