### PR TITLE
Add support for union types (anyOf) in arrays

### DIFF
--- a/lib/ruby_llm/schema/property_schema_collector.rb
+++ b/lib/ruby_llm/schema/property_schema_collector.rb
@@ -36,6 +36,12 @@ module RubyLLM
       def object(...)
         @schemas << Schema.build_property_schema(:object, ...)
       end
+
+      def any_of(&block)
+        union = PropertySchemaCollector.new
+        union.collect(&block)
+        @schemas << { anyOf: union.schemas }
+      end
     end
   end
 end

--- a/spec/ruby_llm/schema_spec.rb
+++ b/spec/ruby_llm/schema_spec.rb
@@ -145,6 +145,51 @@ RSpec.describe RubyLLM::Schema do
         items: {"$ref" => "#/$defs/product"}
       })
     end
+
+    it "supports arrays with union types (anyOf)" do
+      schema_class.array :steps do
+        any_of do
+          object do
+            string :type, enum: ["delay"]
+            number :duration
+          end
+
+          object do
+            string :type, enum: ["email"]
+            string :subject
+            string :template
+          end
+        end
+      end
+
+      properties = schema_class.properties
+      expect(properties[:steps]).to eq({
+        type: "array",
+        items: {
+          anyOf: [
+            {
+              type: "object",
+              properties: {
+                type: { type: "string", enum: ["delay"] },
+                duration: { type: "number" }
+              },
+              required: [:type, :duration],
+              additionalProperties: false
+            },
+            {
+              type: "object",
+              properties: {
+                type: { type: "string", enum: ["email"] },
+                subject: { type: "string" },
+                template: { type: "string" }
+              },
+              required: [:type, :subject, :template],
+              additionalProperties: false
+            }
+          ]
+        }
+      })
+    end
   end
 
   # ===========================================


### PR DESCRIPTION
Hi, thanks for this great library.

I've been trying to build a schema like this:

```rb
class CampaignSchema < RubyLLM::Schema
  array :steps do
    any_of do
      object do
        string :type, enum: ["delay"]
        number :duration
      end

      object do
        string :type, enum: ["email"]
        string :subject
        string :template
      end
    end
  end
end
```

This didn't work quite well. I also tried defining `Step` schema and just referencing it, but that didn't work either.

So here's an attempt at adding support for `any_of` to arrays. I'm attaching AI-generated summary of the PR:

---

## Summary
- Add `any_of` method to PropertySchemaCollector to enable union types within array blocks
- Enable arrays to contain items that can be one of several different object schemas
- Add comprehensive test coverage for array union types

## Problem
Previously, the library didn't support union types (`anyOf`) inside array definitions. Users couldn't create schemas where array items could be one of several different object types, which is a common pattern for polymorphic data structures.

## Solution
Extended the `PropertySchemaCollector` class with an `any_of` method that:
1. Creates a new collector instance to gather union schemas
2. Evaluates the block to collect all possible schema alternatives
3. Wraps the collected schemas in an `anyOf` structure

## Example Usage
```ruby
class CampaignSchema < RubyLLM::Schema
  array :steps do
    any_of do
      object do
        string :type, enum: ["delay"]
        number :duration
      end

      object do
        string :type, enum: ["email"]
        string :subject
        string :template
      end
    end
  end
end
```

## Generated JSON Schema
```json
{
  "type": "array",
  "items": {
    "anyOf": [
      {
        "type": "object",
        "properties": {
          "type": { "type": "string", "enum": ["delay"] },
          "duration": { "type": "number" }
        },
        "required": ["type", "duration"],
        "additionalProperties": false
      },
      {
        "type": "object",
        "properties": {
          "type": { "type": "string", "enum": ["email"] },
          "subject": { "type": "string" },
          "template": { "type": "string" }
        },
        "required": ["type", "subject", "template"],
        "additionalProperties": false
      }
    ]
  }
}
```

## Test Coverage
Added comprehensive test case that verifies the complete JSON schema structure for arrays with union types.

🤖 Generated with [Claude Code](https://claude.ai/code)